### PR TITLE
Point CGC deploy action to updated repo path

### DIFF
--- a/.github/workflows/cgc.yml
+++ b/.github/workflows/cgc.yml
@@ -18,7 +18,7 @@ jobs:
           mv cgc/rnaindel.cwl.new cgc/rnaindel.cwl
           cat cgc/rnaindel.cwl
       - id: cgcdeploy
-        uses: jordan-rash/cgc-go@v0.1.4
+        uses: stjudecloud/cgc-go@v0.1.4
         with:
           file_location: "cgc/rnaindel.cwl"
           shortid: "stjude/rnaindel/rnaindel"


### PR DESCRIPTION
The repository for the CGC deployment action was moved from Jordan's personal namespace to the stjudecloud namespace. This PR updates the action name in our deployment script to reflect that change.